### PR TITLE
Bugfix: Changed timeout time on deployment in YAML file.

### DIFF
--- a/.github/workflows/google-cloudrun.yml
+++ b/.github/workflows/google-cloudrun.yml
@@ -123,7 +123,8 @@ jobs:
             --region ${{env.REGION}} \
             --project ${{env.PROJECT_ID}} \
             --format json \
-            --allow-unauthenticated
+            --allow-unauthenticated \
+            --timeout=59m59s
             
 
       # If required, use the Cloud Run url output in later steps


### PR DESCRIPTION
Description: Changed the deploy script in yaml file to include a timeout of 59m59s.
Reason: Some packages were not saved as the timeout was 5 min before.
Resolution: The timeout for incoming requests should now be 59m59s.