### PR TITLE
Bugfix: Fixed target

### DIFF
--- a/src/main/java/webapi/DAO/TargetDAOImpl.java
+++ b/src/main/java/webapi/DAO/TargetDAOImpl.java
@@ -59,11 +59,13 @@ public class TargetDAOImpl implements TargetDAO
   }
 
   private Target getNewestTarget(List<Target> targets){
-    long highestID = 0;
+    LocalDateTime newestTime = LocalDateTime.of(1970, 1, 1, 1, 1, 1);
     Target toReturn = null;
     for(Target t: targets){
-      if(t.getId()>highestID){
-        highestID=t.getId();
+      DateTimeFormatter formatter = DateTimeFormatter.ofPattern("dd-MM-yyyy k:mm:ss");
+      LocalDateTime tTime = LocalDateTime.parse(t.getTimeToActivate(), formatter);
+      if(tTime.isAfter(newestTime)){
+        newestTime= tTime;
         toReturn = t;
       }
     }


### PR DESCRIPTION
Description: Target earlier prioritized targets with high ID rather than with the latest time.
Reason: Target would not always be right if one was added with an earlier time than the next highest id.
Resolution: Sorts by time now instead of by ID